### PR TITLE
Fix libzippp version and upgrade Catch

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -45,8 +45,6 @@ set(HEADERS
 
 include(GenerateExportHeader)
 
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
 # Create library file from sources
 add_library(${NAME_LIB} SHARED ${SOURCES} ${HEADERS})
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -45,6 +45,8 @@ set(HEADERS
 
 include(GenerateExportHeader)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # Create library file from sources
 add_library(${NAME_LIB} SHARED ${SOURCES} ${HEADERS})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,6 @@ file(GLOB TEST_MISC_SRC ${TEST_SRC_DIR}/Misc/Test_*.cpp)
 
 set(SOURCES
    ${SOURCES}
-   ${TEST_SRC_DIR}/catch_main.cpp
    ${TEST_SRC_DIR}/unit_tests.cpp
    ${TEST_MISC_SRC}
 )
@@ -33,7 +32,6 @@ target_include_directories(${NAME_TEST} PRIVATE
 )
 
 target_link_libraries(${NAME_TEST} PRIVATE
-                      Catch2::Catch2
                       Catch2::Catch2WithMain
                       fmt::fmt
                       magic_enum::magic_enum

--- a/test/src/catch_main.cpp
+++ b/test/src/catch_main.cpp
@@ -1,4 +1,0 @@
-//< This tells the catch header to generate a main
-#define CATCH_CONFIG_MAIN
-
-#include <catch2/catch.hpp>

--- a/test/src/unit_tests.cpp
+++ b/test/src/unit_tests.cpp
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <Drillmethod.hpp>
 #include <HoleType.hpp>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,5 +11,8 @@
     "spdlog",
     "tinyxml2"
   ],
-  "builtin-baseline": "b3e88649a2d57f1d728c4c242b583a77a43a9b22"
+  "overrides": [
+    {"name": "libzippp", "version": "5.0-1.8.0#1"}
+  ],
+  "builtin-baseline": "9b22b40c6c61bf0da2d46346dd44a11e90972cc9"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,5 +10,6 @@
     "nameof",
     "spdlog",
     "tinyxml2"
-  ]
+  ],
+  "builtin-baseline": "b3e88649a2d57f1d728c4c242b583a77a43a9b22"
 }


### PR DESCRIPTION
libzipp produced the following error message 

```text
/usr/bin/ld: ../vcpkg_installed/x64-linux/debug/lib/libzippp_static.a(libzippp.cpp.o): warning: relocation against `_ZSt7nothrow@@GLIBCXX_3.4' in read-only section `.text'
/usr/bin/ld: ../vcpkg_installed/x64-linux/debug/lib/libzippp_static.a(libzippp.cpp.o): relocation R_X86_64_PC32 against symbol `_ZTVN8libzippp8ZipEntryE' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
```

See https://github.com/ctabin/libzippp/issues/158 for the issue report

A guide how to upgrade catch is located at https://github.com/catchorg/Catch2/blob/v3.0.1/docs/migrate-v2-to-v3.md#how-to-migrate-projects-from-v2-to-v3